### PR TITLE
add gdrive source connector

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -4,3 +4,6 @@ AWS_KEY="<key-here>"
 AWS_SECRET="<key-here>"
 UNSTRUCTURED_API_KEY="<key-here>"
 WEAVIATE_CLOUD_API_KEY="<key-here>"
+# store your service account key in json file some safe location and read from the file
+export GOOGLEDRIVE_SERVICE_ACCOUNT_KEY=$(cat /path/to/google_service_account_key.json | base64)
+GOOGLE_DRIVE_ID="<key-here>"

--- a/connectors/source/__init__.py
+++ b/connectors/source/__init__.py
@@ -10,7 +10,14 @@ def register_source_connectors(mcp: FastMCP):
     mcp.tool()(update_s3_source)
     mcp.tool()(delete_s3_source)
 
-    from .azure import create_azure_source, update_azure_source, delete_azure_source
+    from .azure import create_azure_source, delete_azure_source, update_azure_source
+
     mcp.tool()(create_azure_source)
     mcp.tool()(update_azure_source)
     mcp.tool()(delete_azure_source)
+
+    from .gdrive import create_gdrive_source, delete_gdrive_source, update_gdrive_source
+
+    mcp.tool()(create_gdrive_source)
+    mcp.tool()(update_gdrive_source)
+    mcp.tool()(delete_gdrive_source)

--- a/connectors/source/gdrive.py
+++ b/connectors/source/gdrive.py
@@ -52,7 +52,7 @@ async def create_gdrive_source(
     """
     client = ctx.request_context.lifespan_context.client
     config = _prepare_gdrive_source_config(drive_id, recursive, extensions)
-    source_connector = CreateSourceConnector(name=name, type="gdrive", config=config)
+    source_connector = CreateSourceConnector(name=name, type="google_drive", config=config)
 
     try:
         response = await client.sources.create_source_async(

--- a/connectors/source/gdrive.py
+++ b/connectors/source/gdrive.py
@@ -1,0 +1,149 @@
+import os
+from typing import Optional
+
+from mcp.server.fastmcp import Context
+from unstructured_client.models.operations import (
+    CreateSourceRequest,
+    DeleteSourceRequest,
+    GetSourceRequest,
+    UpdateSourceRequest,
+)
+from unstructured_client.models.shared import (
+    CreateSourceConnector,
+    GoogleDriveSourceConnectorConfigInput,
+    UpdateSourceConnector,
+)
+
+from connectors.utils import (
+    create_log_for_created_updated_connector,
+)
+
+
+def _prepare_gdrive_source_config(
+    drive_id: str,
+    recursive: Optional[bool],
+    extensions: Optional[str],
+) -> GoogleDriveSourceConnectorConfigInput:
+    """Prepare the Azure source connector configuration."""
+    return GoogleDriveSourceConnectorConfigInput(
+        drive_id=drive_id,
+        recursive=recursive,
+        extensions=extensions,
+        service_account_key=os.getenv("GOOGLEDRIVE_SERVICE_ACCOUNT_KEY"),
+    )
+
+
+async def create_gdrive_source(
+    ctx: Context,
+    name: str,
+    drive_id: str,
+    recursive: bool = False,
+    extensions: Optional[str] = None,
+) -> str:
+    """Create an gdrive source connector.
+
+    Args:
+        name: A unique name for this connector
+        remote_url: The gdrive URI to the bucket or folder (e.g., gdrive://my-bucket/)
+        recursive: Whether to access subfolders within the bucket
+
+    Returns:
+        String containing the created source connector information
+    """
+    client = ctx.request_context.lifespan_context.client
+    config = _prepare_gdrive_source_config(drive_id, recursive, extensions)
+    source_connector = CreateSourceConnector(name=name, type="gdrive", config=config)
+
+    try:
+        response = await client.sources.create_source_async(
+            request=CreateSourceRequest(create_source_connector=source_connector),
+        )
+        result = create_log_for_created_updated_connector(
+            response,
+            connector_name="GoogleDrive",
+            connector_type="Source",
+            created_or_updated="Created",
+        )
+        return result
+    except Exception as e:
+        return f"Error creating gdrive source connector: {str(e)}"
+
+
+async def update_gdrive_source(
+    ctx: Context,
+    source_id: str,
+    drive_id: Optional[str] = None,
+    recursive: Optional[bool] = None,
+    extensions: Optional[str] = None,
+) -> str:
+    """Update an gdrive source connector.
+
+    Args:
+        source_id: ID of the source connector to update
+        remote_url: The gdrive URI to the bucket or folder
+        recursive: Whether to access subfolders within the bucket
+
+    Returns:
+        String containing the updated source connector information
+    """
+    client = ctx.request_context.lifespan_context.client
+
+    # Get the current source connector configuration
+    try:
+        get_response = await client.sources.get_source_async(
+            request=GetSourceRequest(source_id=source_id),
+        )
+        current_config = get_response.source_connector_information.config
+    except Exception as e:
+        return f"Error retrieving source connector: {str(e)}"
+
+    # Update configuration with new values
+    config = dict(current_config)
+
+    if drive_id is not None:
+        config["drive_id"] = drive_id
+
+    if recursive is not None:
+        config["recursive"] = recursive
+
+    if extensions is not None:
+        config["extensions"] = extensions
+
+    source_connector = UpdateSourceConnector(config=config)
+
+    try:
+        response = await client.sources.update_source_async(
+            request=UpdateSourceRequest(
+                source_id=source_id,
+                update_source_connector=source_connector,
+            ),
+        )
+        result = create_log_for_created_updated_connector(
+            response,
+            connector_name="GoogleDrive",
+            connector_type="Source",
+            created_or_updated="Updated",
+        )
+        return result
+    except Exception as e:
+        return f"Error updating gdrive source connector: {str(e)}"
+
+
+async def delete_gdrive_source(ctx: Context, source_id: str) -> str:
+    """Delete an gdrive source connector.
+
+    Args:
+        source_id: ID of the source connector to delete
+
+    Returns:
+        String containing the result of the deletion
+    """
+    client = ctx.request_context.lifespan_context.client
+
+    try:
+        _ = await client.sources.delete_source_async(
+            request=DeleteSourceRequest(source_id=source_id),
+        )
+        return f"gdrive Source Connector with ID {source_id} deleted successfully"
+    except Exception as e:
+        return f"Error deleting gdrive source connector: {str(e)}"


### PR DESCRIPTION
per ML-[1010](https://unstructured-ai.atlassian.net/browse/ML-1010), this PR is to add google drive source connector to MCP server.

Screenshots to prove are below via running `uv run python minimal_client/run.py server,py`
* create tool: 
![image](https://github.com/user-attachments/assets/f96e316c-fb39-4ab1-b3bd-0c66ce3e1988)
*update gdrive: you. have to specify the updated param and the source connector id in the same query to get passed easily, otherwise, the loss of memory in the minimal_client will keep asking you to verify what the particular id is for. 
![image](https://github.com/user-attachments/assets/8e612cf1-2ad5-41ed-8675-2c5ec6dc5b45)


**note:** use a service account that you have admin access to it and store the account key into a json file and access it as a reference string (for example: convert it to a base64 string). See in `.env.template` for details