### PR TITLE
Add job related tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 - ** Destination connector adding**: weaviate, astradb
 
+- ** Add `list_jobs`, `get_job_info`, `cancel_job` tools
+
 ### Fixes
 
 - fix bugs for source connector config access

--- a/server.py
+++ b/server.py
@@ -432,16 +432,16 @@ async def list_jobs(
     # Sort jobs by name
     sorted_jobs = sorted(
         response.response_list_jobs,
-        key=lambda job: job.name.lower(),
+        key=lambda job: job.created_at,
     )
 
     if not sorted_jobs:
         return "No Jobs found"
 
     # Format response
-    result = ["Available Jobs:"]
+    result = ["Available Jobs by created time:"]
     for job in sorted_jobs:
-        result.append(f"- {job.name} (ID: {job.id})")
+        result.append(f"- JOB ID: {job.id})")
 
     return "\n".join(result)
 

--- a/uv.lock
+++ b/uv.lock
@@ -592,8 +592,8 @@ wheels = [
 
 [[package]]
 name = "uns-mcp"
-version = "0.1.0"
-source = { virtual = "." }
+version = "0.1.1"
+source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
this PR is to add below 3 tools to interact with an Unstructured job
- list_jobs
- get_job_info
- cancel_job

Screenshots for proof are below:
* list_jobs
<img width="542" alt="image" src="https://github.com/user-attachments/assets/ac52fe22-21fd-43da-b3e1-343817636029" />

* list jobs by status of 'running' 

<img width="566" alt="image" src="https://github.com/user-attachments/assets/315781ad-60ca-49f9-838b-f884b480fe62" />

* get_job_info

<img width="566" alt="image" src="https://github.com/user-attachments/assets/4135edeb-1302-40ca-81a3-c87e0494e50e" />

* cancel_job

<img width="566" alt="image" src="https://github.com/user-attachments/assets/73121296-542a-4245-94b7-f5d846a7ca30" />
