### PR TITLE
Log unstructured client calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - ** Destination connector adding**: MongoDB
 
-- Capability to log calls to UnstructuredClient
+- Capability to log request parameters to UnstructuredClient's AsyncHttpClient, no error response is logged by this mechanism.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - ** Destination connector adding**: MongoDB
 
+- Capability to log calls to UnstructuredClient
+
 ### Fixes
 
 - avoid client startup error if env not defined

--- a/README.md
+++ b/README.md
@@ -255,6 +255,9 @@ Anthropic provides `MCP Inspector` tool to debug/test your MCP server. Run the f
 mcp dev uns_mcp/server.py
 ```
 
+If you need to log calls to `UnstructuredClient`, set the environment variable `DEBUG_API_REQUESTS=false`.
+The logs are stored in the file `unstructured_client.log`, which can be examined to debug calls to `UnstructuredClient` functions.
+
 ## Running locally minimal client
 ```
 uv run python minimal_client/client.py uns_mcp/server.py

--- a/README.md
+++ b/README.md
@@ -255,8 +255,8 @@ Anthropic provides `MCP Inspector` tool to debug/test your MCP server. Run the f
 mcp dev uns_mcp/server.py
 ```
 
-If you need to log calls to `UnstructuredClient`, set the environment variable `DEBUG_API_REQUESTS=false`.
-The logs are stored in the file `unstructured_client.log`, which can be examined to debug calls to `UnstructuredClient` functions.
+If you need to log request call parameters to `UnstructuredClient`, set the environment variable `DEBUG_API_REQUESTS=false`.
+The logs are stored in a file with the format `unstructured-client-{date}.log`, which can be examined to debug request call parameters to `UnstructuredClient` functions.
 
 ## Running locally minimal client
 ```

--- a/uns_mcp/custom_http_client.py
+++ b/uns_mcp/custom_http_client.py
@@ -1,0 +1,159 @@
+from unstructured_client.httpclient import AsyncHttpClient
+import json
+import httpx
+import logging
+import os
+from typing import Any, Optional, Union
+
+
+def log_request_params(
+    logger,
+    method,
+    url,
+    content=None,
+    data=None,
+    files=None,
+    json_value=None,
+    params=None,
+    headers=None,
+    cookies=None,
+    timeout=None,
+    extensions=None,
+):
+    """Logs request parameters in a formatted way."""
+    logger.info("--- Request Parameters ---")
+    logger.info(f"Method: {method}")
+    logger.info(f"URL: {url}")
+
+    if content is not None:
+        logger.info("Content:")
+        if isinstance(content, bytes):
+            try:
+                logger.info(content.decode("utf-8"))
+            except UnicodeDecodeError:
+                logger.info(content)
+        else:
+            logger.info(content)
+
+    if data is not None:
+        logger.info("Data:")
+
+        if isinstance(data, dict):
+            logger.info(json.dumps(data, indent=4))
+        else:
+            logger.info(data)
+
+    if files is not None:
+        logger.info("Files:")
+        logger.info(files)
+
+    if json_value is not None:
+        logger.info("JSON:")
+        logger.info(json.dumps(json_value, indent=4))
+
+    if params is not None:
+        logger.info("Params:")
+        logger.info(json.dumps(params, indent=4))
+
+    if headers is not None:
+        logger.info("Headers:")
+        logger.info(json.dumps(headers, indent=4))
+
+    if cookies is not None:
+        logger.info("Cookies:")
+        logger.info(cookies)
+
+    if timeout is not None:
+        logger.info(f"Timeout: {timeout}")
+
+    if extensions is not None:
+        logger.info("Extensions:")
+        logger.info(extensions)
+    logger.info("--- End Request Parameters ---")
+
+
+class CustomHttpClient(AsyncHttpClient):
+    client: AsyncHttpClient
+
+    def __init__(self, client: AsyncHttpClient):
+        self.client = client
+        self.log_file = os.path.abspath(
+            "unstructured_client.log"
+        )  # Store absolute log path
+        self.logger = logging.getLogger(__name__)  # Get logger for this module
+        self.logger.setLevel(logging.INFO)  # Set default log level
+
+        # Create file handler
+        file_handler = logging.FileHandler(self.log_file)
+        file_handler.setLevel(logging.INFO)
+
+        # Create formatter and add it to the handler
+        formatter = logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        )
+        file_handler.setFormatter(formatter)
+
+        # Add the handler to the logger
+        self.logger.addHandler(file_handler)
+
+    async def send(
+        self,
+        request: httpx.Request,
+        *,
+        stream: bool = False,
+        auth: Union[
+            httpx._types.AuthTypes, httpx._client.UseClientDefault, None
+        ] = httpx.USE_CLIENT_DEFAULT,
+        follow_redirects: Union[
+            bool, httpx._client.UseClientDefault
+        ] = httpx.USE_CLIENT_DEFAULT,
+    ) -> httpx.Response:
+        return await self.client.send(
+            request, stream=stream, auth=auth, follow_redirects=follow_redirects
+        )
+
+    def build_request(
+        self,
+        method: str,
+        url: httpx._types.URLTypes,
+        *,
+        content: Optional[httpx._types.RequestContent] = None,
+        data: Optional[httpx._types.RequestData] = None,
+        files: Optional[httpx._types.RequestFiles] = None,
+        json: Optional[Any] = None,
+        params: Optional[httpx._types.QueryParamTypes] = None,
+        headers: Optional[httpx._types.HeaderTypes] = None,
+        cookies: Optional[httpx._types.CookieTypes] = None,
+        timeout: Union[
+            httpx._types.TimeoutTypes, httpx._client.UseClientDefault
+        ] = httpx.USE_CLIENT_DEFAULT,
+        extensions: Optional[httpx._types.RequestExtensions] = None,
+    ) -> httpx.Request:
+        log_request_params(
+            self.logger,
+            method,
+            url,
+            content,
+            data,
+            files,
+            json,
+            params,
+            headers,
+            cookies,
+            timeout,
+            extensions,
+        )
+
+        return self.client.build_request(
+            method,
+            url,
+            content=content,
+            data=data,
+            files=files,
+            json=json,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            timeout=timeout,
+            extensions=extensions,
+        )

--- a/uns_mcp/custom_http_client.py
+++ b/uns_mcp/custom_http_client.py
@@ -1,4 +1,5 @@
 from unstructured_client.httpclient import AsyncHttpClient
+from datetime import datetime
 import json
 import httpx
 import logging
@@ -78,7 +79,7 @@ class CustomHttpClient(AsyncHttpClient):
     def __init__(self, client: AsyncHttpClient):
         self.client = client
         self.log_file = os.path.abspath(
-            "unstructured_client.log"
+            f"unstructured-client-{datetime.now().strftime('%Y-%m-%d-%H-%M-%S')}.log"
         )  # Store absolute log path
         self.logger = logging.getLogger(__name__)  # Get logger for this module
         self.logger.setLevel(logging.INFO)  # Set default log level

--- a/uns_mcp/server.py
+++ b/uns_mcp/server.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sys
 from contextlib import asynccontextmanager
@@ -482,7 +483,8 @@ async def get_job_info(ctx: Context, job_id: str) -> str:
     result.append(f"Workflow name: {info.workflow_name}")
     result.append(f"Workflow id: {info.workflow_id}")
     result.append(f"Runtime: {info.runtime}")
-
+    result.append(f"Raw result: {json.dumps(json.loads(info.json()), indent=2)}")
+    
     return "\n".join(result)
 
 

--- a/uns_mcp/server.py
+++ b/uns_mcp/server.py
@@ -68,7 +68,14 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
     if not api_key:
         raise ValueError("UNSTRUCTURED_API_KEY environment variable is required")
 
-    client = UnstructuredClient(api_key_auth=api_key)
+    DEBUG_API_REQUESTS = os.environ.get("DEBUG_API_REQUESTS", "False").lower() == "true" #get env variable
+    if DEBUG_API_REQUESTS:
+        from custom_http_client import CustomHttpClient
+        import httpx
+        client = UnstructuredClient(api_key_auth=api_key, async_client=CustomHttpClient(httpx.AsyncClient()))
+    else:
+        client = UnstructuredClient(api_key_auth=api_key)
+    
     try:
         yield AppContext(client=client)
     finally:


### PR DESCRIPTION
To activate it, the variable DEBUG_API_REQUESTS needs to be set to true.

Unstructured client calls happen from the server, so logging is not visible if done from the server. It should be possible to contact the client and use the logging capabilities of the client, but for this to happen, the context of the client would need to be passed to the unstructured client at every call, which would mean modifying the calls to unstructured client functions to pass the mcp client context.

Unless a better solution is identified, the code currently creates a file named `unstructured_client.log` where the logging info is stored.