### PR TITLE
fix:Force dotenv load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - avoid client startup error if env not defined
+- force server using env var from .env instead of fetching them from system first
 
 
 ## 0.1.1

--- a/uns_mcp/server.py
+++ b/uns_mcp/server.py
@@ -5,10 +5,11 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import AsyncIterator, Optional
 
+import uvicorn
 from docstring_extras import add_custom_node_examples  # relative import required by mcp
 from dotenv import load_dotenv
-from mcp.server.fastmcp import Context, FastMCP
 from mcp.server import Server
+from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.sse import SseServerTransport
 from starlette.applications import Starlette
 from starlette.requests import Request
@@ -38,7 +39,6 @@ from unstructured_client.models.shared import (
     WorkflowState,
 )
 from unstructured_client.models.shared.createworkflow import CreateWorkflowTypedDict
-import uvicorn
 
 from connectors import register_connectors
 
@@ -48,7 +48,7 @@ def load_environment_variables() -> None:
     Load environment variables from .env file.
     Raises an error if critical environment variables are missing.
     """
-    load_dotenv()
+    load_dotenv(override=True)
     required_vars = ["UNSTRUCTURED_API_KEY"]
 
     for var in required_vars:
@@ -484,7 +484,7 @@ async def get_job_info(ctx: Context, job_id: str) -> str:
     result.append(f"Workflow id: {info.workflow_id}")
     result.append(f"Runtime: {info.runtime}")
     result.append(f"Raw result: {json.dumps(json.loads(info.json()), indent=2)}")
-    
+
     return "\n".join(result)
 
 
@@ -515,9 +515,9 @@ def create_starlette_app(mcp_server: Server, *, debug: bool = False) -> Starlett
 
     async def handle_sse(request: Request) -> None:
         async with sse.connect_sse(
-                request.scope,
-                request.receive,
-                request._send,  # noqa: SLF001
+            request.scope,
+            request.receive,
+            request._send,  # noqa: SLF001
         ) as (read_stream, write_stream):
             await mcp_server.run(
                 read_stream,
@@ -533,10 +533,11 @@ def create_starlette_app(mcp_server: Server, *, debug: bool = False) -> Starlett
         ],
     )
 
+
 if __name__ == "__main__":
     load_environment_variables()
     if len(sys.argv) < 2:
-        # server is directly being invoked from client 
+        # server is directly being invoked from client
         mcp.run()
     else:
         # server is running as HTTP SSE server
@@ -544,12 +545,12 @@ if __name__ == "__main__":
         mcp_server = mcp._mcp_server  # noqa: WPS437
 
         import argparse
-        
-        parser = argparse.ArgumentParser(description='Run MCP SSE-based server')
-        parser.add_argument('--host', default='127.0.0.1', help='Host to bind to')
-        parser.add_argument('--port', type=int, default=8080, help='Port to listen on')
+
+        parser = argparse.ArgumentParser(description="Run MCP SSE-based server")
+        parser.add_argument("--host", default="127.0.0.1", help="Host to bind to")
+        parser.add_argument("--port", type=int, default=8080, help="Port to listen on")
         args = parser.parse_args()
-        
+
         # Bind SSE request handling to MCP server
         starlette_app = create_starlette_app(mcp_server, debug=True)
 


### PR DESCRIPTION
After we decoupled server and client process, `os.getenv()` will try to load the env vars from system first and then fall back to the env vars in `.env`. 

In case we have same env var names but with different values, this repo suggests to fetch values from .env file. This PR is to allow .env to override system. 