### PR TITLE
[Feat]: add onedrive source

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -25,3 +25,8 @@ NEO4J_PASSWORD="<PASSWORD>"
 MONGO_DB_CONNECTION_STRING="<CONNECTION_STRING>"
 LOG_LEVEL="INFO"
 CONFIRM_TOOL_USE='true'
+
+# one drive credential
+ONEDRIVE_CLIENT_ID="<client-id-here>"
+ONEDRIVE_CLIENT_CRED="<client-cred-here>"
+ONEDRIVE_TENANT_ID="<tenant-id-here>"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - ** Destination connector adding**: MongoDB
 
+- ** Source connector addding**: OneDrive
+
 - List all the tools in a table.
 
 - Capability to only log request parameters to UnstructuredClient's AsyncHttpClient, no error response is logged by this mechanism.

--- a/connectors/source/__init__.py
+++ b/connectors/source/__init__.py
@@ -4,6 +4,7 @@ from mcp.server.fastmcp import FastMCP
 def register_source_connectors(mcp: FastMCP):
     """Register all source connector tools with the MCP server."""
     from .s3 import create_s3_source, delete_s3_source, update_s3_source
+
     # Register S3 source connector tools
     mcp.tool()(create_s3_source)
     mcp.tool()(update_s3_source)
@@ -20,3 +21,13 @@ def register_source_connectors(mcp: FastMCP):
     mcp.tool()(create_gdrive_source)
     mcp.tool()(update_gdrive_source)
     mcp.tool()(delete_gdrive_source)
+
+    from .onedrive import (
+        create_onedrive_source,
+        delete_onedrive_source,
+        update_onedrive_source,
+    )
+
+    mcp.tool()(create_onedrive_source)
+    mcp.tool()(update_onedrive_source)
+    mcp.tool()(delete_onedrive_source)

--- a/connectors/source/onedrive.py
+++ b/connectors/source/onedrive.py
@@ -30,8 +30,11 @@ def _prepare_onedrive_source_config(
         path=path,
         user_pname=user_pname,
         recursive=recursive,
-        client_id=os.getenv("ONEDRIVE_CLIENT_ID"),
         client_cred=os.getenv("ONEDRIVE_CLIENT_CRED"),
+        # client id and tenant id are not strictly sensitive
+        # but they are cumbersome to pass in as arguments
+        # so made them env vars
+        client_id=os.getenv("ONEDRIVE_CLIENT_ID"),
         tenant=os.getenv("ONEDRIVE_TENANT_ID"),
     )
     if authority_url:

--- a/connectors/source/onedrive.py
+++ b/connectors/source/onedrive.py
@@ -54,11 +54,13 @@ async def create_onedrive_source(
 
     Args:
         name: A unique name for this connector
-        path: The path to the OneDrive folder
-        user_pname: OneDrive user principal name
+        path: The path to the target folder in the OneDrive account,
+            starting with the account’s root folder
+        user_pname: The User Principal Name (UPN) for the OneDrive user account in Entra ID.
+            This is typically the user’s email address.
         recursive: Whether to access subfolders
-        authority_url: Authority URL for authentication
-        tenant: Tenant ID for authentication
+        authority_url: The authentication token provider URL for the Entra ID app registration.
+            The default is https://login.microsoftonline.com.
 
     Returns:
         String containing the created source connector information
@@ -90,16 +92,22 @@ async def update_onedrive_source(
     recursive: Optional[bool] = None,
     authority_url: Optional[str] = None,
     tenant: Optional[str] = None,
+    client_id: Optional[str] = None,
 ) -> str:
     """Update a OneDrive source connector.
 
     Args:
         source_id: ID of the source connector to update
-        path: The path to the OneDrive folder
-        user_pname: OneDrive user principal name
+        path: The path to the target folder in the OneDrive account,
+            starting with the account’s root folder
+        user_pname: The User Principal Name (UPN) for the OneDrive user account in Entra ID.
+            This is typically the user’s email address.
         recursive: Whether to access subfolders
-        authority_url: Authority URL for authentication
-        tenant: Tenant ID for authentication
+        authority_url: The authentication token provider URL for the Entra ID app registration.
+            The default is https://login.microsoftonline.com.
+        tenant: The directory (tenant) ID of the Entra ID app registration.
+        client_id: The application (client) ID of the Microsoft Entra ID app registration
+            that has access to the OneDrive account.
 
     Returns:
         String containing the updated source connector information
@@ -126,6 +134,8 @@ async def update_onedrive_source(
         config["authority_url"] = authority_url
     if tenant is not None:
         config["tenant"] = tenant
+    if client_id is not None:
+        config["client_id"] = client_id
 
     source_connector = UpdateSourceConnector(config=config)
 

--- a/connectors/source/onedrive.py
+++ b/connectors/source/onedrive.py
@@ -1,0 +1,167 @@
+import os
+from typing import Optional
+
+from mcp.server.fastmcp import Context
+from unstructured_client.models.operations import (
+    CreateSourceRequest,
+    DeleteSourceRequest,
+    GetSourceRequest,
+    UpdateSourceRequest,
+)
+from unstructured_client.models.shared import (
+    CreateSourceConnector,
+    OneDriveSourceConnectorConfigInput,
+    UpdateSourceConnector,
+)
+
+from connectors.utils import (
+    create_log_for_created_updated_connector,
+)
+
+
+def _prepare_onedrive_source_config(
+    path: str,
+    user_pname: str,
+    recursive: Optional[bool] = False,
+    authority_url: Optional[str] = None,
+    tenant: Optional[str] = None,
+) -> OneDriveSourceConnectorConfigInput:
+    """Prepare the OneDrive source connector configuration."""
+    config = OneDriveSourceConnectorConfigInput(
+        path=path,
+        user_pname=user_pname,
+        recursive=recursive,
+        client_id=os.getenv("ONEDRIVE_CLIENT_ID"),
+        client_cred=os.getenv("ONEDRIVE_CLIENT_CRED"),
+    )
+    if authority_url:
+        config.authority_url = authority_url
+    if tenant:
+        config.tenant = tenant
+    return config
+
+
+async def create_onedrive_source(
+    ctx: Context,
+    name: str,
+    path: str,
+    user_pname: str,
+    recursive: bool = False,
+    authority_url: Optional[str] = None,
+    tenant: Optional[str] = None,
+) -> str:
+    """Create a OneDrive source connector.
+
+    Args:
+        name: A unique name for this connector
+        path: The path to the OneDrive folder
+        user_pname: OneDrive user principal name
+        recursive: Whether to access subfolders
+        authority_url: Authority URL for authentication
+        tenant: Tenant ID for authentication
+
+    Returns:
+        String containing the created source connector information
+    """
+    client = ctx.request_context.lifespan_context.client
+    config = _prepare_onedrive_source_config(path, user_pname, recursive, authority_url, tenant)
+    source_connector = CreateSourceConnector(name=name, type="onedrive", config=config)
+
+    try:
+        response = await client.sources.create_source_async(
+            request=CreateSourceRequest(create_source_connector=source_connector),
+        )
+        result = create_log_for_created_updated_connector(
+            response,
+            connector_name="OneDrive",
+            connector_type="Source",
+            created_or_updated="Created",
+        )
+        return result
+    except Exception as e:
+        return f"Error creating OneDrive source connector: {str(e)}"
+
+
+async def update_onedrive_source(
+    ctx: Context,
+    source_id: str,
+    path: Optional[str] = None,
+    user_pname: Optional[str] = None,
+    recursive: Optional[bool] = None,
+    authority_url: Optional[str] = None,
+    tenant: Optional[str] = None,
+) -> str:
+    """Update a OneDrive source connector.
+
+    Args:
+        source_id: ID of the source connector to update
+        path: The path to the OneDrive folder
+        user_pname: OneDrive user principal name
+        recursive: Whether to access subfolders
+        authority_url: Authority URL for authentication
+        tenant: Tenant ID for authentication
+
+    Returns:
+        String containing the updated source connector information
+    """
+    client = ctx.request_context.lifespan_context.client
+
+    try:
+        get_response = await client.sources.get_source_async(
+            request=GetSourceRequest(source_id=source_id),
+        )
+        current_config = get_response.source_connector_information.config
+    except Exception as e:
+        return f"Error retrieving source connector: {str(e)}"
+
+    config = dict(current_config)
+
+    if path is not None:
+        config["path"] = path
+    if user_pname is not None:
+        config["user_pname"] = user_pname
+    if recursive is not None:
+        config["recursive"] = recursive
+    if authority_url is not None:
+        config["authority_url"] = authority_url
+    if tenant is not None:
+        config["tenant"] = tenant
+
+    source_connector = UpdateSourceConnector(config=config)
+
+    try:
+        response = await client.sources.update_source_async(
+            request=UpdateSourceRequest(
+                source_id=source_id,
+                update_source_connector=source_connector,
+            ),
+        )
+        result = create_log_for_created_updated_connector(
+            response,
+            connector_name="OneDrive",
+            connector_type="Source",
+            created_or_updated="Updated",
+        )
+        return result
+    except Exception as e:
+        return f"Error updating OneDrive source connector: {str(e)}"
+
+
+async def delete_onedrive_source(ctx: Context, source_id: str) -> str:
+    """Delete a OneDrive source connector.
+
+    Args:
+        source_id: ID of the source connector to delete
+
+    Returns:
+        String containing the result of the deletion
+    """
+    client = ctx.request_context.lifespan_context.client
+
+    try:
+        _ = await client.sources.delete_source_async(
+            request=DeleteSourceRequest(source_id=source_id),
+        )
+        return f"OneDrive Source Connector with ID {source_id} deleted successfully"
+    except Exception as e:
+        return f"Error deleting OneDrive source connector: {str(e)}"

--- a/connectors/source/onedrive.py
+++ b/connectors/source/onedrive.py
@@ -24,7 +24,6 @@ def _prepare_onedrive_source_config(
     user_pname: str,
     recursive: Optional[bool] = False,
     authority_url: Optional[str] = None,
-    tenant: Optional[str] = None,
 ) -> OneDriveSourceConnectorConfigInput:
     """Prepare the OneDrive source connector configuration."""
     config = OneDriveSourceConnectorConfigInput(
@@ -33,11 +32,10 @@ def _prepare_onedrive_source_config(
         recursive=recursive,
         client_id=os.getenv("ONEDRIVE_CLIENT_ID"),
         client_cred=os.getenv("ONEDRIVE_CLIENT_CRED"),
+        tenant=os.getenv("ONEDRIVE_TENANT_ID"),
     )
     if authority_url:
         config.authority_url = authority_url
-    if tenant:
-        config.tenant = tenant
     return config
 
 
@@ -47,8 +45,7 @@ async def create_onedrive_source(
     path: str,
     user_pname: str,
     recursive: bool = False,
-    authority_url: Optional[str] = None,
-    tenant: Optional[str] = None,
+    authority_url: Optional[str] = "https://login.microsoftonline.com",
 ) -> str:
     """Create a OneDrive source connector.
 
@@ -64,7 +61,7 @@ async def create_onedrive_source(
         String containing the created source connector information
     """
     client = ctx.request_context.lifespan_context.client
-    config = _prepare_onedrive_source_config(path, user_pname, recursive, authority_url, tenant)
+    config = _prepare_onedrive_source_config(path, user_pname, recursive, authority_url)
     source_connector = CreateSourceConnector(name=name, type="onedrive", config=config)
 
     try:


### PR DESCRIPTION
this PR is to add onedrive as a source connector.

Prior to test: follow the unstructured [tutorial](https://docs.unstructured.io/ui/sources/onedrive) to get all the credentials needed to set up the connector. Note
- ensure your principal name is the email address you sign in to OneDrive app

For test, use below prompts and make changes to fit your own case.
- `Can you create a one drive source connector with a name you generate;path=tshen-test;principal-name=<youemailaddress to sign in to onedrive>`
  - expected output:
   <img width="564" alt="image" src="https://github.com/user-attachments/assets/ce5a9195-b11a-4b42-8d24-d770c14d4014" />
- `Please use the just created source connector and the destination of layout-parser-paper (ID: 5ac2737c-e403-416c-89b2-3eb1aa6ae4f0) to create a custom workflow including partitioner node with auto strategy`
   -  expected output:
   
     <img width="564" alt="image" src="https://github.com/user-attachments/assets/cb4d6b2c-f034-4806-9062-bdbf2e87f8d5" />

-  run and check job status
   -  expected output:
   
     <img width="564" alt="image" src="https://github.com/user-attachments/assets/020a4cab-8a96-4217-b2d4-36dedf43b6cc" />

   
- result shown in destination:

     
    <img width="815" alt="image" src="https://github.com/user-attachments/assets/b0712c45-d132-4054-b05f-0bc5337b9281" />





