### PR TITLE
clarify how to convert google service account key

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -26,9 +26,11 @@ MONGO_DB_CONNECTION_STRING="<CONNECTION_STRING>"
 LOG_LEVEL="INFO"
 CONFIRM_TOOL_USE='true'
 
-# store your service account key in json file some safe location and read from the file
-export GOOGLEDRIVE_SERVICE_ACCOUNT_KEY=$(cat /path/to/google_service_account_key.json | base64)
-GOOGLE_DRIVE_ID="<key-here>"
+# store your service account key in a json file in some safe location
+# convert the json file into a string via command: cat /path/to/google_service_account_key.json | base64
+# then use the string as the value for GOOGLEDRIVE_SERVICE_ACCOUNT_KEY
+GOOGLEDRIVE_SERVICE_ACCOUNT_KEY="<converted string>"
+
 
 # below is the databricks creds
 DATABRICKS_CLIENT_ID="<client-id>"

--- a/README.md
+++ b/README.md
@@ -144,8 +144,13 @@ The main difference here is it becomes easier to set breakpoints on the server s
 # in one terminal, run the server:
 python uns_mcp/server.py --host 127.0.0.1 --port 8080
 
+or
+make sse-server
+
 # in another terminal, run the client:
 python minimal_client/client.py "http://127.0.0.1:8080/sse"
+or
+make sse-client
 ```
 
 Hint: `ctrl+c` out of the client first, then the server. Otherwise the server appears to hang.


### PR DESCRIPTION
this PR is to clarify we should use the converted string for google drive `GOOGLEDRIVE_SERVICE_ACCOUNT_KEY` instead of previously we had `export GOOGLEDRIVE_SERVICE_ACCOUNT_KEY=$(cat .local/personal_google_service_account_key.json | base64)` in the .env.

Instead, you should first run `cat .local/personal_google_service_account_key.json | base64 ` to get the string and post that string into your `GOOGLEDRIVE_SERVICE_ACCOUNT_KEY` area. See change in `.env.template`

In addition, also modified readme about running server and client a little bit. 