### PR TITLE
bump unstructured-client version to 0.32.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "pytest-asyncio>=0.25.3",
     "notebook>=7.3.3",
     "python-dotenv>=1.0.1",
-    "unstructured-client>=0.31.6",
+    "unstructured-client>=0.32.0",
     "pip"
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.12"
 
 [[package]]
@@ -1841,12 +1842,13 @@ requires-dist = [
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-asyncio", specifier = ">=0.25.3" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
-    { name = "unstructured-client", specifier = ">=0.31.6" },
+    { name = "unstructured-client", specifier = ">=0.32.0" },
 ]
+provides-extras = ["dev"]
 
 [[package]]
 name = "unstructured-client"
-version = "0.31.6"
+version = "0.32.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -1860,9 +1862,9 @@ dependencies = [
     { name = "requests-toolbelt" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/42/13656872e0417f453c50d9c29b9ac839ef84289c1da9df6ba19b9fe1ac65/unstructured_client-0.31.6.tar.gz", hash = "sha256:75ccc248b0fbbabbb536bea13667e4b16b5a90353fe88a6d0a72d3e9d30c2de2", size = 78358 }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/aa/60edb5443f9b01c3d98e02ab2faf037f7985446b2ac957b4c8ee88e4566e/unstructured_client-0.32.0.tar.gz", hash = "sha256:2d691f6c3390a91b6a2e2e738503770a96f05357146be05b2068c7c4d6986f47", size = 78804 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/3a/2933648530cfa9374f8b261aaba9cfa1eaf08d9848b8310664e5140ba25a/unstructured_client-0.31.6-py3-none-any.whl", hash = "sha256:8fb4a81b9451e61b0455f07a7915410464a195745b6359c7dbe9d022668b26a3", size = 177547 },
+    { url = "https://files.pythonhosted.org/packages/20/89/6dae3de36efc370c388da2567433dbc2d3ed56c8bfefa1d180e0119c3ffd/unstructured_client-0.32.0-py3-none-any.whl", hash = "sha256:6131a645dad7da3528812c5ac6db387d9e73d751aa0b7ad745608acc67807bd9", size = 178218 },
 ]
 
 [[package]]


### PR DESCRIPTION
this PR is to bump unstructured-client to 0.32.0 which contains fix for sharepoint, jira, confluence, snowflake connectors.