### PR TITLE
feat: add sharepoint source

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -40,3 +40,8 @@ DATABRICKS_CLIENT_SECRET="<client-secret>"
 ONEDRIVE_CLIENT_ID="<client-id-here>"
 ONEDRIVE_CLIENT_CRED="<client-cred-here>"
 ONEDRIVE_TENANT_ID="<tenant-id-here>"
+
+# sharepoint credential
+SHAREPOINT_CLIENT_ID="<client-id-here>"
+SHAREPOINT_CLIENT_CRED="<client-cred-here>"
+SHAREPOINT_TENANT_ID="<tenant-id-here>"

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.egg-info*
 *.ipynb_checkpoints*
 build
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - ** Destination connector adding**: MongoDB, Databricks Volumes, Databricks Volumes Delta Table
 
-- ** Source connector adding**: OneDrive
+- ** Source connector adding**: OneDrive, Sharepoint
 
 - List all the tools in a table.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 - Ability to run the minimal client and server separately (relies on the HTTP SSE interaface)
 
-- ** Destination connector adding**: MongoDB, Databricks Volumes, Databricks Volumes Delta Table, Pinecone
+- **Destination connector adding**: MongoDB, Databricks Volumes, Databricks Volumes Delta Table, Pinecone
 
-- ** Source connector adding**: OneDrive, Salesforce, Sharepoint
+- **Source connector adding**: OneDrive, Salesforce, Sharepoint
 
 - List all the tools in a table.
 
@@ -16,17 +16,6 @@
 
 - avoid client startup error if env not defined
 - force server using env var from .env instead of fetching them from system first
-
-
-## 0.1.2-dev
-
-### Enhancements
-
-### Features
-
-- ** Destination connector adding**: Pinecone
-
-### Fixes
 
 
 ## 0.1.1

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ To use the tool that creates/updates/deletes a connector, the credentials for th
 | `ONEDRIVE_CLIENT_ID`, `ONEDRIVE_CLIENT_CRED`,`ONEDRIVE_TENANT_ID`| required to create One Drive connector via `uns-mcp` server, see how in [documentation](https://docs.unstructured.io/ui/destinations/onedrive) |
 | `PINECONE_API_KEY` | required to create Pinecone vector DB connector via `uns-mcp` server, see how in [documentation](https://docs.unstructured.io/ui/destinations/pinecone) |
 | `SALESFORCE_CONSUMER_KEY`,`SALESFORCE_PRIVATE_KEY` | required to create salesforce source connector via `uns-mcp` server, see how in [documentation](https://docs.unstructured.io/ingestion/source-connectors/salesforce)|
+| `SHAREPOINT_CLIENT_ID`, `SHAREPOINT_CLIENT_CRED`,`SHAREPOINT_TENANT_ID`| required to create One Drive connector via `uns-mcp` server, see how in [documentation](https://docs.unstructured.io/ui/sources/sharepoint) |
 | `LOG_LEVEL` | Used to set logging level for our `minimal_client`, e.g. set to ERROR to get everything  |
 | `CONFIRM_TOOL_USE` | set to true so that `minimal_client` can confirm execution before each tool call |
 | `DEBUG_API_REQUESTS` | set to true so that `uns_mcp/server.py` can output request parameters for better debugging |

--- a/README.md
+++ b/README.md
@@ -53,24 +53,25 @@ uv run uns_mcp/server.py
 
 To use the tool that creates/updates/deletes a connector, the credentials for that specific connector must be defined in your .env file. Below is the list of `credentials` for the connectors we support:
 
-| Credential Name | Description |
-|------|-------------|
-| `ANTHROPIC_API_KEY` | required to run the `minimal_client` to interact with our server. |
-| `AWS_KEY`, `AWS_SECRET`| required to create S3 connector via `uns-mcp` server, see how in [documentation](https://docs.unstructured.io/api-reference/workflow/sources/s3) and [here](https://docs.unstructured.io/api-reference/workflow/destinations/s3) |
-| `WEAVIATE_CLOUD_API_KEY` | required to create Weaviate vector db connector, see how in [documentation](https://docs.unstructured.io/api-reference/workflow/destinations/weaviate) |
-| `FIRECRAWL_API_KEY` | required to use Firecrawl tools in `external/firecrawl.py`, sign up on [Firecrawl](https://www.firecrawl.dev/) and get an API key. |
-| `ASTRA_DB_APPLICATION_TOKEN`, `ASTRA_DB_API_ENDPOINT` | required to create Astradb connector via `uns-mcp` server, see how in [documentation](https://docs.unstructured.io/ui/destinations/astradb)|
-| `AZURE_CONNECTION_STRING`| required option 1 to create Azure connector via ``uns-mcp`` server, see how in [documentation](https://docs.unstructured.io/ui/sources/azure-blob-storage) |
-| `AZURE_ACCOUNT_NAME`+`AZURE_ACCOUNT_KEY`| required option 2 to create Azure connector via `uns-mcp` server, see how in [documentation](https://docs.unstructured.io/ui/sources/azure-blob-storage)|
-| `AZURE_ACCOUNT_NAME`+`AZURE_SAS_TOKEN` | required option 3 to create Azure connector via `uns-mcp` server, see how in [documentation](https://docs.unstructured.io/ui/sources/azure-blob-storage) |
-| `NEO4J_PASSWORD` | required to create Neo4j connector via `uns-mcp` server, see how in [documentation](https://docs.unstructured.io/ui/destinations/neo4j) |
-| `MONGO_DB_CONNECTION_STRING` | required to create Mongodb connector via `uns-mcp` server, see how in [documentation](https://docs.unstructured.io/ui/destinations/mongodb) |
-| `GOOGLEDRIVE_SERVICE_ACCOUNT_KEY` | a string value. The original server account key (follow [documentation](https://docs.unstructured.io/ui/sources/google-drive)) is in json file, run `cat /path/to/google_service_account_key.json | base64` in terminal to get the string value  |
+| Credential Name | Description                                                                                                                                                                                                                                                  |
+|------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `ANTHROPIC_API_KEY` | required to run the `minimal_client` to interact with our server.                                                                                                                                                                                            |
+| `AWS_KEY`, `AWS_SECRET`| required to create S3 connector via `uns-mcp` server, see how in [documentation](https://docs.unstructured.io/api-reference/workflow/sources/s3) and [here](https://docs.unstructured.io/api-reference/workflow/destinations/s3)                             |
+| `WEAVIATE_CLOUD_API_KEY` | required to create Weaviate vector db connector, see how in [documentation](https://docs.unstructured.io/api-reference/workflow/destinations/weaviate)                                                                                                       |
+| `FIRECRAWL_API_KEY` | required to use Firecrawl tools in `external/firecrawl.py`, sign up on [Firecrawl](https://www.firecrawl.dev/) and get an API key.                                                                                                                           |
+| `ASTRA_DB_APPLICATION_TOKEN`, `ASTRA_DB_API_ENDPOINT` | required to create Astradb connector via `uns-mcp` server, see how in [documentation](https://docs.unstructured.io/ui/destinations/astradb)                                                                                                                  |
+| `AZURE_CONNECTION_STRING`| required option 1 to create Azure connector via ``uns-mcp`` server, see how in [documentation](https://docs.unstructured.io/ui/sources/azure-blob-storage)                                                                                                   |
+| `AZURE_ACCOUNT_NAME`+`AZURE_ACCOUNT_KEY`| required option 2 to create Azure connector via `uns-mcp` server, see how in [documentation](https://docs.unstructured.io/ui/sources/azure-blob-storage)                                                                                                     |
+| `AZURE_ACCOUNT_NAME`+`AZURE_SAS_TOKEN` | required option 3 to create Azure connector via `uns-mcp` server, see how in [documentation](https://docs.unstructured.io/ui/sources/azure-blob-storage)                                                                                                     |
+| `NEO4J_PASSWORD` | required to create Neo4j connector via `uns-mcp` server, see how in [documentation](https://docs.unstructured.io/ui/destinations/neo4j)                                                                                                                      |
+| `MONGO_DB_CONNECTION_STRING` | required to create Mongodb connector via `uns-mcp` server, see how in [documentation](https://docs.unstructured.io/ui/destinations/mongodb)                                                                                                                  |
+| `GOOGLEDRIVE_SERVICE_ACCOUNT_KEY` | a string value. The original server account key (follow [documentation](https://docs.unstructured.io/ui/sources/google-drive)) is in json file, run `cat /path/to/google_service_account_key.json                                                            | base64` in terminal to get the string value  |
 | `DATABRICKS_CLIENT_ID`,`DATABRICKS_CLIENT_SECRET` | required to create Databricks volume/delta table connector via `uns-mcp` server, see how in [documentation](https://docs.unstructured.io/ui/destinations/databricks-volumes) and [here](https://docs.unstructured.io/ui/destinations/databricks-delta-table) |
-| `ONEDRIVE_CLIENT_ID`, `ONEDRIVE_CLIENT_CRED`,`ONEDRIVE_TENANT_ID`| required to create One Drive connector via `uns-mcp` server, see how in [documentation](https://docs.unstructured.io/ui/destinations/onedrive) |
-| `LOG_LEVEL` | Used to set logging level for our `minimal_client`, e.g. set to ERROR to get everything  |
-| `CONFIRM_TOOL_USE` | set to true so that `minimal_client` can confirm execution before each tool call |
-| `DEBUG_API_REQUESTS` | set to true so that `uns_mcp/server.py` can output request parameters for better debugging |
+| `ONEDRIVE_CLIENT_ID`, `ONEDRIVE_CLIENT_CRED`,`ONEDRIVE_TENANT_ID`| required to create One Drive connector via `uns-mcp` server, see how in [documentation](https://docs.unstructured.io/ui/destinations/onedrive)                                                                                                               |
+| `SHAREPOINT_CLIENT_ID`, `SHAREPOINT_CLIENT_CRED`,`SHAREPOINT_TENANT_ID`| required to create Sharepoint connector via `uns-mcp` server, see how in [documentation](https://docs.unstructured.io/ui/sources/sharepoint)                                                                                                              |
+| `LOG_LEVEL` | Used to set logging level for our `minimal_client`, e.g. set to ERROR to get everything                                                                                                                                                                      |
+| `CONFIRM_TOOL_USE` | set to true so that `minimal_client` can confirm execution before each tool call                                                                                                                                                                             |
+| `DEBUG_API_REQUESTS` | set to true so that `uns_mcp/server.py` can output request parameters for better debugging                                                                                                                                                                   |
 
 
 ### Firecrawl Source

--- a/connectors/source/__init__.py
+++ b/connectors/source/__init__.py
@@ -31,3 +31,13 @@ def register_source_connectors(mcp: FastMCP):
     mcp.tool()(create_onedrive_source)
     mcp.tool()(update_onedrive_source)
     mcp.tool()(delete_onedrive_source)
+
+    from .sharepoint import (
+        create_sharepoint_source,
+        update_sharepoint_source,
+        delete_sharepoint_source,
+    )
+
+    mcp.tool()(create_sharepoint_source)
+    mcp.tool()(update_sharepoint_source)
+    mcp.tool()(delete_sharepoint_source)

--- a/connectors/source/sharepoint.py
+++ b/connectors/source/sharepoint.py
@@ -21,7 +21,6 @@ from connectors.utils import (
 
 def _prepare_sharepoint_source_config(
     site: str,
-    tenant: str,
     user_pname: str,
     path: Optional[str],
     recursive: Optional[bool],
@@ -46,7 +45,6 @@ async def create_sharepoint_source(
     ctx: Context,
     name: str,
     site: str,
-    tenant: str,
     user_pname: str,
     path: Optional[str] = None,
     recursive: bool = False,
@@ -57,7 +55,6 @@ async def create_sharepoint_source(
     Args:
         name: A unique name for this connector
         site: The SharePoint site to connect to
-        tenant: The tenant ID for the SharePoint site
         user_pname: The username for the SharePoint site
         path: The path within the SharePoint site
         recursive: Whether to access subfolders within the site
@@ -68,7 +65,7 @@ async def create_sharepoint_source(
     """
     client = ctx.request_context.lifespan_context.client
     config = _prepare_sharepoint_source_config(
-        site, tenant, user_pname, path, recursive, authority_url
+        site, user_pname, path, recursive, authority_url
     )
     source_connector = CreateSourceConnector(name=name, type="sharepoint", config=config)
 
@@ -91,7 +88,6 @@ async def update_sharepoint_source(
     ctx: Context,
     source_id: str,
     site: Optional[str] = None,
-    tenant: Optional[str] = None,
     user_pname: Optional[str] = None,
     path: Optional[str] = None,
     recursive: Optional[bool] = None,
@@ -102,7 +98,6 @@ async def update_sharepoint_source(
     Args:
         source_id: ID of the source connector to update
         site: The SharePoint site to connect to
-        tenant: The tenant ID for the SharePoint site
         user_pname: The username for the SharePoint site
         path: The path within the SharePoint site
         recursive: Whether to access subfolders within the site
@@ -127,8 +122,6 @@ async def update_sharepoint_source(
 
     if site is not None:
         config["site"] = site
-    if tenant is not None:
-        config["tenant"] = tenant
     if user_pname is not None:
         config["user_pname"] = user_pname
     if path is not None:

--- a/connectors/source/sharepoint.py
+++ b/connectors/source/sharepoint.py
@@ -1,0 +1,178 @@
+import os
+from typing import Optional
+
+from mcp.server.fastmcp import Context
+from unstructured_client.models.operations import (
+    CreateSourceRequest,
+    DeleteSourceRequest,
+    GetSourceRequest,
+    UpdateSourceRequest,
+)
+from unstructured_client.models.shared import (
+    CreateSourceConnector,
+    SharePointSourceConnectorConfigInput,
+    UpdateSourceConnector,
+)
+
+from connectors.utils import (
+    create_log_for_created_updated_connector,
+)
+
+
+def _prepare_sharepoint_source_config(
+    site: str,
+    tenant: str,
+    user_pname: str,
+    path: Optional[str],
+    recursive: Optional[bool],
+    authority_url: Optional[str],
+) -> SharePointSourceConnectorConfigInput:
+    """Prepare the SharePoint source connector configuration."""
+    config = SharePointSourceConnectorConfigInput(
+        site=site,
+        user_pname=user_pname,
+        client_id=os.getenv("SHAREPOINT_CLIENT_ID"),
+        client_cred=os.getenv("SHAREPOINT_CLIENT_CRED"),
+        tenant=os.getenv("SHAREPOINT_TENANT_ID"),
+        path=path,
+        recursive=recursive,
+    )
+    if authority_url:
+        config.authority_url = authority_url
+    return config
+
+
+async def create_sharepoint_source(
+    ctx: Context,
+    name: str,
+    site: str,
+    tenant: str,
+    user_pname: str,
+    path: Optional[str] = None,
+    recursive: bool = False,
+    authority_url: Optional[str] = None,
+) -> str:
+    """Create a SharePoint source connector.
+
+    Args:
+        name: A unique name for this connector
+        site: The SharePoint site to connect to
+        tenant: The tenant ID for the SharePoint site
+        user_pname: The username for the SharePoint site
+        path: The path within the SharePoint site
+        recursive: Whether to access subfolders within the site
+        authority_url: The authority URL for authentication
+
+    Returns:
+        String containing the created source connector information
+    """
+    client = ctx.request_context.lifespan_context.client
+    config = _prepare_sharepoint_source_config(
+        site, tenant, user_pname, path, recursive, authority_url
+    )
+    source_connector = CreateSourceConnector(name=name, type="sharepoint", config=config)
+
+    try:
+        response = await client.sources.create_source_async(
+            request=CreateSourceRequest(create_source_connector=source_connector),
+        )
+        result = create_log_for_created_updated_connector(
+            response,
+            connector_name="SharePoint",
+            connector_type="Source",
+            created_or_updated="Created",
+        )
+        return result
+    except Exception as e:
+        return f"Error creating SharePoint source connector: {str(e)}"
+
+
+async def update_sharepoint_source(
+    ctx: Context,
+    source_id: str,
+    site: Optional[str] = None,
+    tenant: Optional[str] = None,
+    user_pname: Optional[str] = None,
+    path: Optional[str] = None,
+    recursive: Optional[bool] = None,
+    authority_url: Optional[str] = None,
+) -> str:
+    """Update a SharePoint source connector.
+
+    Args:
+        source_id: ID of the source connector to update
+        site: The SharePoint site to connect to
+        tenant: The tenant ID for the SharePoint site
+        user_pname: The username for the SharePoint site
+        path: The path within the SharePoint site
+        recursive: Whether to access subfolders within the site
+        authority_url: The authority URL for authentication
+
+    Returns:
+        String containing the updated source connector information
+    """
+    client = ctx.request_context.lifespan_context.client
+
+    # Get the current source connector configuration
+    try:
+        get_response = await client.sources.get_source_async(
+            request=GetSourceRequest(source_id=source_id),
+        )
+        current_config = get_response.source_connector_information.config
+    except Exception as e:
+        return f"Error retrieving source connector: {str(e)}"
+
+    # Update configuration with new values
+    config = dict(current_config)
+
+    if site is not None:
+        config["site"] = site
+    if tenant is not None:
+        config["tenant"] = tenant
+    if user_pname is not None:
+        config["user_pname"] = user_pname
+    if path is not None:
+        config["path"] = path
+    if recursive is not None:
+        config["recursive"] = recursive
+    if authority_url is not None:
+        config["authority_url"] = authority_url
+
+    source_connector = UpdateSourceConnector(config=config)
+
+    try:
+        response = await client.sources.update_source_async(
+            request=UpdateSourceRequest(
+                source_id=source_id,
+                update_source_connector=source_connector,
+            ),
+        )
+        result = create_log_for_created_updated_connector(
+            response,
+            connector_name="SharePoint",
+            connector_type="Source",
+            created_or_updated="Updated",
+        )
+        return result
+    except Exception as e:
+        return f"Error updating SharePoint source connector: {str(e)}"
+
+
+async def delete_sharepoint_source(ctx: Context, source_id: str) -> str:
+    """Delete a SharePoint source connector.
+
+    Args:
+        source_id: ID of the source connector to delete
+
+    Returns:
+        String containing the result of the deletion
+    """
+    client = ctx.request_context.lifespan_context.client
+
+    try:
+        _ = await client.sources.delete_source_async(
+            request=DeleteSourceRequest(source_id=source_id),
+        )
+        return f"SharePoint Source Connector with ID {source_id} deleted successfully"
+    except Exception as e:
+        return f"Error deleting SharePoint source connector: {str(e)}"


### PR DESCRIPTION
This PR aims to add `sharepoint` as a source connector. 
Prior to test: follow the unstructured [tutorial](https://docs.unstructured.io/ui/sources/sharepoint) to get all the credentials needed to set up the connector.

### Testing
Use the query below or your own query to test in `minimal_client`

- `Can you create a sharepoint source connector with name=mcp-sharepoint-src;site-url=https://unstructuredio.sharepoint.com;path=Shared Documents;principal-name=devops@unstructuredio.onmicrosoft.com`

    <img width="1385" alt="image" src="https://github.com/user-attachments/assets/8fab95e1-9c93-49db-a311-3c012f17f905" />

- `Can you use the just created sharepoint source connector and destination mcp-s3-dest id=98f18708-8a06-48f6-8e78-df29e06c7ee5 to create a custom workflow with an auto strategy partitioner`

    <img width="1382" alt="image" src="https://github.com/user-attachments/assets/cee8a743-0741-4319-a52f-af8a6eaaf555" />

- run and check job status

    <img width="1379" alt="image" src="https://github.com/user-attachments/assets/4ec007f5-6bc7-42e9-bce3-4367c9c8b6c3" />

- results in UI and destination data view:

   <img width="1160" alt="image" src="https://github.com/user-attachments/assets/acbec244-0acb-41f2-bda4-a9e42ccba760" />


