### PR TITLE
feat(ci): add version-bump workflow for Renovate PRs

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,25 @@
+name: Version Bump
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  version-bump:
+    if: github.event.pull_request.user.login == 'utic-renovate[bot]'
+    uses: Unstructured-IO/infra/.github/workflows/version-bump.yml@main
+    with:
+      component-paths: '["."]'
+      default-bump: patch
+      update-changelog: true
+      update-lockfile: true
+      renovate-app-id: ${{ vars.RENOVATE_APP_ID }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+      private-pypi-url: ${{ secrets.PRIVATE_PYPI_INDEX_URL }}
+      renovate-app-private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- Adds automated version bumping for Renovate dependency update PRs
- Uses the shared reusable workflow from `Unstructured-IO/infra`
- Automatically bumps version in `pyproject.toml`, updates `CHANGELOG.md`, and refreshes `uv.lock`

## How it works
When Renovate opens or updates a PR, this workflow:
1. Detects which components were changed
2. Parses conventional commit messages to determine bump type (major/minor/patch)
3. Bumps the version, updates changelog, and commits back to the PR branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces an automated workflow with `contents: write` that can push commits to PR branches; misconfiguration could cause unintended version/changelog updates.
> 
> **Overview**
> Introduces a new `version-bump` GitHub Actions workflow that runs on `pull_request` events targeting `main`, but only when the PR author is `utic-renovate[bot]`.
> 
> The job delegates to the reusable workflow in `Unstructured-IO/infra`, configured to default to a patch bump and to automatically update the changelog and lockfile, using repository secrets/vars for Renovate app credentials and a token with write access to contents.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 541a644573b09cb4d96eb2a65649a816e91a5e0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->